### PR TITLE
[Update]管理者、顧客それぞれのログイン後遷移ページの指定、ログアウト後の遷移ページの指定

### DIFF
--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -2,7 +2,13 @@
 
 class Admin::SessionsController < Devise::SessionsController
   # before_action :configure_sign_in_params, only: [:create]
+  def after_sign_in_path_for(resource)
+    admin_path
+  end
 
+  def after_sign_out_path_for(resource)
+    new_admin_session_path
+  end
   # GET /resource/sign_in
   # def new
   #   super

--- a/app/controllers/public/registrations_controller.rb
+++ b/app/controllers/public/registrations_controller.rb
@@ -3,7 +3,9 @@
 class Public::RegistrationsController < Devise::RegistrationsController
   # before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
-
+  def after_sign_in_path_for(resource)
+    customers_path(current_customer)
+  end
   # GET /resource/sign_up
   # def new
   #   super

--- a/app/controllers/public/sessions_controller.rb
+++ b/app/controllers/public/sessions_controller.rb
@@ -25,9 +25,9 @@ class Public::SessionsController < Devise::SessionsController
   # def configure_sign_in_params
   #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
   # end
-  
+
   protected
-  
+
   def customer_state
     @customer = Customer.find_by(email: params[:customer][:email])
 
@@ -37,9 +37,9 @@ class Public::SessionsController < Devise::SessionsController
       else
         sign_in(@customer)
         flash[:notice] = "ログインしました。"
-        redirect_to customers_path
+        redirect_to root_path
       end
     end
   end
-  
+
 end


### PR DESCRIPTION
管理者ログイン後は注文履歴一覧ページ、ログアウト後は管理者ログインページに遷移するようにしています。
顧客ログイン後ログアウト後はtopページに、新規登録後はマイページに遷移するようにしています。
テスト見ながらやったんで遷移先ページはあってると思います