### PR TITLE
[Fix]cart_itemsコントローラー内のスペルミス修正

### DIFF
--- a/app/controllers/public/cart_items_controller.rb
+++ b/app/controllers/public/cart_items_controller.rb
@@ -10,7 +10,7 @@ class Public::CartItemsController < ApplicationController
     item = Item.find(params[:cart_item][:item_id])
     cart_item = CartItem.find_by(customer_id: current_customer.id, item_id: item.id)
     unless cart_item.nil?
-      if (params[:cart_item][:amout]).blank?
+      if (params[:cart_item][:amount]).blank?
         flash[:error] = "個数を選択してください"
         redirect_to item_path(item)
       else

--- a/app/views/public/cart_items/index.html.erb
+++ b/app/views/public/cart_items/index.html.erb
@@ -24,7 +24,7 @@
               <% @cart_items.each do |cart_item| %>
                 <tr>
                   <td class="align-middle">
-                    <%= image_tag cart_item.item.get_image, size: "50x40" %><br>
+                    <%= image_tag cart_item.item.get_image, size: "50x40" %>
                     <%= cart_item.item.name %>
                   </td>
                   <td class="align-middle"><%= cart_item.item.with_tax_price.to_s(:delimited) %></td>


### PR DESCRIPTION
コントローラー内のスペルが間違っていて数量追加ができなかったのでスペルミスを修正しました。
カートの商品画像の後ろにbrタグ入れてましたが消しました。