### PR TITLE
[Add]商品一覧と詳細にジャンル検索を追加

### DIFF
--- a/app/controllers/public/items_controller.rb
+++ b/app/controllers/public/items_controller.rb
@@ -1,6 +1,12 @@
 class Public::ItemsController < ApplicationController
   def index
-    @items = Item.page(params[:page]).per(8)
+    if params[:name].nil?
+      @items = Item.all
+      @paginate_items = @items.page(params[:page]).per(8)
+    else
+      @items = Genre.find_by(name: params[:name]).items
+      @paginate_items = @items.page(params[:page]).per(8)
+    end
   end
 
   def show

--- a/app/views/admin/genres/_search_genre.html.erb
+++ b/app/views/admin/genres/_search_genre.html.erb
@@ -1,0 +1,10 @@
+<div class="search_genre pb-5 border border-dark mb-5">
+  <h6 class="text-center border-bottom border-dark">ジャンル検索</h6>
+  <ul class="px-2">
+    <% genres.each do |genre| %>
+      <li style="list-style: none;">
+        <%= link_to genre.name, items_path(name: genre.name), class:"text-dark"%>
+      </li>
+    <% end %>
+  </ul>
+</div>

--- a/app/views/public/items/_index.html.erb
+++ b/app/views/public/items/_index.html.erb
@@ -1,0 +1,14 @@
+<div class="row">
+  <% items.each do |item| %>
+    <div class="col-sm-3">
+      <p>
+        <%= link_to item_path(item) do %>
+          <%= image_tag item.get_image, size: "120x80" %>
+        <% end %>
+      </p>
+      <div><%= item.name %></div>
+      <div><%= "￥#{item.with_tax_price.to_s(:delimited)}" %></div>
+    </div>
+  <% end %>
+</div>
+<%= paginate items %>

--- a/app/views/public/items/index.html.erb
+++ b/app/views/public/items/index.html.erb
@@ -1,25 +1,17 @@
 <div class="container">
   <div class="row pt-5">
-    <div class="col-2"></div>
-    <div class="col-10">
-      <h4>
-        商品一覧
-        <span><%= "(全#{Item.all.count}件)" %></span>
-      </h4>
-      <div class="row">
-        <% @items.each do |item| %>
-          <div class="col-sm-3">
-            <p>
-              <%= link_to item_path(item) do %>
-                <%= image_tag item.get_image, size: "120x80" %>
-              <% end %>
-            </p>
-            <div><%= item.name %></div>
-            <div><%= "￥#{item.with_tax_price.to_s(:delimited)}" %></div>
-          </div>
-        <% end %>
-      </div>
-        <%= paginate @items %>
+    <div class="col-xl-2 col-md-3">
+      <%= render "admin/genres/search_genre", genres: Genre.all %>
+    </div>
+    <div class="col-xl-10 col-md-9">
+      <% if params[:name].nil? %>
+        <h4 class="d-inline-block">商品一覧</h4>
+        <span><%= "(全#{@items.count}件)" %></span>
+      <% else %>
+        <h4 class="d-inline-block"><%= params[:name] %>一覧</h4>
+        <span><%= "(全#{@items.count}件)" %></span>
+      <% end %>
+      <%= render "index", items: @paginate_items %>
     </div>
   </div>
 </div>

--- a/app/views/public/items/show.html.erb
+++ b/app/views/public/items/show.html.erb
@@ -1,7 +1,9 @@
 <div class="container">
   <div class="row pt-5">
-    <div class="col-3"></div>
-    <div class="col-9">
+    <div class="col-xl-2 col-md-3">
+      <%= render "admin/genres/search_genre", genres: Genre.all %>
+    </div>
+    <div class="col-xl-10 col-md-9">
       <div class="row">
         <div class="col-sm-4">
           <%= image_tag @item.get_image, size: "150x120" %>


### PR DESCRIPTION
商品一覧画面と商品詳細画面に、部分テンプレート化したジャンル検索機能をつけました。ジャンル名を押すとそのジャンルの一覧に遷移すると思います。
商品一覧の一覧部分は部分テンプレートにしました。