### PR TITLE
Fix/public/confirm reload

### DIFF
--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -55,8 +55,12 @@ class Public::OrdersController < ApplicationController
   end
 
   def show
-    @order = Order.find(params[:id])
-    @cart_items = @order.order_items
+    if (params[:id] == "confirm")
+      redirect_to new_order_path
+    else
+      @order = Order.find(params[:id])
+      @cart_items = @order.order_items
+    end
   end
 
   def complete

--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -55,8 +55,8 @@ class Public::OrdersController < ApplicationController
   end
 
   def show
-    if (params[:id] == "confirm")
-      redirect_to new_order_path
+    if (params[:id] == "confirm") #注文確認画面でのページ更新時にカートに遷移させる
+      redirect_to cart_items_path
     else
       @order = Order.find(params[:id])
       @cart_items = @order.order_items

--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -1,4 +1,5 @@
 class Public::OrdersController < ApplicationController
+  before_action :authenticate_customer!
 
   def new
     @order = Order.new
@@ -21,10 +22,10 @@ class Public::OrdersController < ApplicationController
       @order.postal_code = params[:order][:postal_code]
       @order.address = params[:order][:address]
       @order.name = params[:order][:name]
-      if @order.postal_code.blank? || @order.address.blank? || @order.name.blank?
+      if @order.form_blank? || @order.postal_code !~ /\A\d{7}\z/ #フォームが空もしくは郵便番号電話が7桁以外だとはじく
         @customer = current_customer
         @addresses = @customer.addresses
-        flash[:error] = "フォームに値を入れてください"
+        flash[:error] = "フォームが空、もしくは郵便番号が7桁ではありません"
         render :new
       end
     end
@@ -65,11 +66,10 @@ class Public::OrdersController < ApplicationController
 
   def complete
   end
-
+  
+  private
   def order_params
     params.require(:order).permit(:postal_code,:address, :name, :shipping_cost, :total_payment, :payment_method,:customer_id, :status)
   end
-
-  before_action :authenticate_customer!
 
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -21,6 +21,8 @@ class Order < ApplicationRecord
     preparing_ship: 3, #発送準備中
     shipped: 4 #発送済み
   }
-  
 
+  def form_blank?
+    self.postal_code.blank? || self.address.blank? || self.name.blank?
+  end
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -15,29 +15,29 @@
         <ul class="navbar-nav ml-auto d-flex align-items-center">
           <% if admin_signed_in? %>
             <li>
-              <%= link_to "商品一覧", admin_items_path, class: 'nav-link text-dark' %>
+              <%= link_to "商品一覧", admin_items_path, class: 'nav-link text-dark btn' %>
             </li>
             <li>
-              <%= link_to "会員一覧", admin_customers_path, class: 'nav-link text-dark' %>
+              <%= link_to "会員一覧", admin_customers_path, class: 'nav-link text-dark btn' %>
             </li>
             <li>
-              <%= link_to "注文履歴一覧", admin_path, class: 'nav-link text-dark' %>
+              <%= link_to "注文履歴一覧", admin_path, class: 'nav-link text-dark btn' %>
             </li>
             <li>
-              <%= link_to "ジャンル一覧", admin_genres_path, class: 'nav-link text-dark' %>
+              <%= link_to "ジャンル一覧", admin_genres_path, class: 'nav-link text-dark btn' %>
             </li>
             <li>
-              <%= link_to "ログアウト", destroy_admin_session_path, method: :delete, class: 'nav-link text-dark' %>
+              <%= link_to "ログアウト", destroy_admin_session_path, method: :delete, class: 'nav-link text-dark btn' %>
             </li>
           <% elsif customer_signed_in? %>
             <li class="d-flex align-items-center mr-5">
               <div class="mr-5">ようこそ<%= current_customer.first_name %>さん！！</div>
             </li>
             <li>
-              <%= link_to "マイページ", customers_path, class: 'nav-link text-dark' %>
+              <%= link_to "マイページ", customers_path, class: 'nav-link text-dark btn' %>
             </li>
             <li>
-              <%= link_to "商品一覧", items_path, class: 'nav-link text-dark' %>
+              <%= link_to "商品一覧", items_path, class: 'nav-link text-dark btn' %>
             </li>
             <li class="position-relative">
               <%= link_to cart_items_path, class: 'nav-link text-dark btn' do %>
@@ -50,23 +50,23 @@
               <% end %>
             </li>
             <li>
-              <%= link_to "ログアウト", destroy_customer_session_path, method: :delete, class: 'nav-link text-dark' %>
+              <%= link_to "ログアウト", destroy_customer_session_path, method: :delete, class: 'nav-link text-dark btn' %>
             </li>
           <% else %>
             <li>
-              <%= link_to "About", about_path, class: 'nav-link text-dark' %>
+              <%= link_to "About", about_path, class: 'nav-link text-dark btn' %>
             </li>
             <li>
-              <%= link_to "商品一覧", items_path, class: 'nav-link text-dark' %>
+              <%= link_to "商品一覧", items_path, class: 'nav-link text-dark btn' %>
             </li>
             <li>
-              <%= link_to "新規登録", new_customer_registration_path, class: 'nav-link text-dark' %>
+              <%= link_to "新規登録", new_customer_registration_path, class: 'nav-link text-dark btn' %>
             </li>
             <li>
-              <%= link_to "管理者ログイン", new_admin_session_path, class: 'nav-link text-dark' %>
+              <%= link_to "管理者ログイン", new_admin_session_path, class: 'nav-link text-dark btn' %>
             </li>
             <li>
-              <%= link_to "ログイン", new_customer_session_path, class: 'nav-link text-dark' %>
+              <%= link_to "ログイン", new_customer_session_path, class: 'nav-link text-dark btn' %>
             </li>
           <% end %>
         </ul>

--- a/app/views/public/orders/confirm.html.erb
+++ b/app/views/public/orders/confirm.html.erb
@@ -8,22 +8,22 @@
       <table class="table table-bordered table-responsive bg-light">
         <thead class="thead-light">
           <tr>
-            <th>商品名</th>
-            <th>単価(税込)</th>
-            <th>数量</th>
-            <th>小計</th>
+            <th class="align-middle">商品名</th>
+            <th class="align-middle">単価(税込)</th>
+            <th class="align-middle">数量</th>
+            <th class="align-middle">小計</th>
           </tr>
         </thead>
         <tbody>
           <% total = 0 %>
           <% @cart_items.each do |cart_item| %>
           <tr>
-            <td><%= image_tag cart_item.item.get_image, size: "50x50" %>
+            <td class="align-middle"><%= image_tag cart_item.item.get_image, size: "50x50" %>
                 <%= cart_item.item.name %>
             </td>
-            <td><%= (cart_item.item.price*1.1).floor.to_s(:delimited) %></td>
-            <td><%= cart_item.amount %></td>
-            <td><%= subtotal = ((cart_item.item.price*cart_item.amount)*1.1).floor.to_s(:delimited) %></td>
+            <td class="align-middle"><%= (cart_item.item.price*1.1).floor.to_s(:delimited) %></td>
+            <td class="align-middle"><%= cart_item.amount %></td>
+            <td class="align-middle"><%= subtotal = ((cart_item.item.price*cart_item.amount)*1.1).floor.to_s(:delimited) %></td>
           </tr>
           <% total += ((cart_item.item.price*cart_item.amount)*1.1).to_i %>
           <% end %>
@@ -54,13 +54,13 @@
     </div>
   </div>
   <div class="row">
-    <div class="col-md-4 text-center">
+    <div class="col-8 mx-auto">
       <h5><strong>支払方法</strong></h5>
-      <p><%= @order.payment_method_i18n %></p>
+      <p class="ml-5"><%= @order.payment_method_i18n %></p>
     <div>
     <div>
       <h5><strong>お届け先</strong></h5>
-      <p>
+      <p class="ml-5">
         〒<%= @order.postal_code %>
         <%= @order.address %><br>
         <%= @order.name %>

--- a/app/views/public/orders/index.html.erb
+++ b/app/views/public/orders/index.html.erb
@@ -4,19 +4,19 @@
     <table class="table table-bordered bg-light">
       <thead class="thead-light">
         <tr>
-          <th>注文日</th>
-          <th>配送先</th>
-          <th>注文商品</th>
-          <th>支払金額</th>
-          <th>ステータス</th>
-          <th>注文詳細</th>
+          <th class="align-middle">注文日</th>
+          <th class="align-middle">配送先</th>
+          <th class="align-middle">注文商品</th>
+          <th class="align-middle">支払金額</th>
+          <th class="align-middle">ステータス</th>
+          <th class="align-middle">注文詳細</th>
         </tr>
       </thead>
       <tbody>
         <% @orders.each do |order| %>
           <tr>
             <td class="align-middle"><%= order.created_at.strftime('%Y/%m/%d') %></td>
-            <td>
+            <td class="align-middle">
               〒<%= order.postal_code %><br>
               <%= order.address %><br>
               <%= order.name %>


### PR DESCRIPTION
注文確認画面の下のほうのレイアウトが気になったんでちょっと変えてます。
注文確認画面でページ更新したときに、showアクションでparams[:id]がconfirmだったら無理やりカートに遷移するさせるようにしました。エラーは吐かなくなったと思います。この変更で通常の詳細ページに影響がないか一応確認してますが、心配なのでマージした後、お二方も試してみてくださいm(__)m