### PR TITLE
[Fix]検索機能で空白を入れると全商品が表示されていたので修正

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -17,6 +17,10 @@ class Item < ApplicationRecord
   end
 
   def self.search_for(word)
-    Item.where("name LIKE ?", "%#{word}%")
+    unless word.blank?
+      Item.where("name LIKE ?", "%#{word}%")
+    else
+      Item.where(name: word)
+    end
   end
 end


### PR DESCRIPTION
検索で入力せずに検索をかけると全商品が表示されていたので、itemモデルファイルに空白の時は完全一致にして探すようにして対策しました。